### PR TITLE
#130 로그인 로직 수정

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,7 +18,6 @@ android {
     buildTypes {
         debug {
             buildConfigField "String", "APIServerBaseURL", keystoreProperties.getProperty("apiServerURL")
-            buildConfigField "String", "TMapApiKey",keystoreProperties.getProperty("TMapApiKey")
         }
 
         release {

--- a/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/HanRiverMeetupApplication.java
+++ b/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/HanRiverMeetupApplication.java
@@ -1,6 +1,7 @@
 package com.depromeet.hanriver.hanrivermeetup;
 
 import android.app.Application;
+import android.content.SharedPreferences;
 import android.graphics.drawable.AnimationDrawable;
 import android.graphics.drawable.ColorDrawable;
 import android.os.Handler;
@@ -9,6 +10,7 @@ import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.app.AppCompatDialog;
 import android.widget.ImageView;
 
+import com.depromeet.hanriver.hanrivermeetup.common.PreferencesManager;
 import com.depromeet.hanriver.hanrivermeetup.datamodel.meeting.ActivityDataModel;
 import com.depromeet.hanriver.hanrivermeetup.datamodel.meeting.CommentDataModel;
 import com.depromeet.hanriver.hanrivermeetup.datamodel.meeting.IActivityDataModel;
@@ -30,6 +32,7 @@ import com.depromeet.hanriver.hanrivermeetup.datamodel.mypage.MyPageTab3DataMode
 import com.depromeet.hanriver.hanrivermeetup.datamodel.timeline.ITimelineDataModel;
 import com.depromeet.hanriver.hanrivermeetup.datamodel.mypage.MyPageTab1DataModel;
 import com.depromeet.hanriver.hanrivermeetup.datamodel.timeline.TimelineDataModel;
+import com.depromeet.hanriver.hanrivermeetup.firebase.CustomFirebaseInstanceIDService;
 import com.depromeet.hanriver.hanrivermeetup.fragment.meeting.MeetingCategoryViewModel;
 import com.depromeet.hanriver.hanrivermeetup.fragment.meeting.MeetingCommentViewModel;
 import com.depromeet.hanriver.hanrivermeetup.fragment.meeting.MeetingDetailViewModel;
@@ -92,11 +95,6 @@ public class HanRiverMeetupApplication extends Application {
     @NonNull
     private final ICommentDataModel mCommentDataModel;
 
-
-//    @NonNull
-//    private final ICreateRoomDataModel mCreateRoomDataModel;
-
-
     public static HanRiverMeetupApplication getInstance(){
         return hanRiverMeetupApplication;
     }
@@ -105,9 +103,20 @@ public class HanRiverMeetupApplication extends Application {
     public void onCreate() {
         super.onCreate();
         hanRiverMeetupApplication = this;
+        setPreferences();
     }
 
+    public void setPreferences() {
+        PreferencesManager.setManager(this);
+        PreferencesManager.setNickname("");
+        PreferencesManager.setFacebookToken("");
+        PreferencesManager.setUserID("");
+        String fcmToken = PreferencesManager.getFcmToken();
 
+        if(fcmToken.isEmpty()) {
+            PreferencesManager.setFcmToken(CustomFirebaseInstanceIDService.getToken());
+        }
+    }
 
     public HanRiverMeetupApplication() {
         mActivityDataModel = new ActivityDataModel();
@@ -124,7 +133,6 @@ public class HanRiverMeetupApplication extends Application {
         mPhotoDataModel = new PhotoDataModel();
         mEtcDataModel = new EtcDataModel();
         mCommentDataModel = new CommentDataModel();
-
     }
 
     @NonNull
@@ -204,7 +212,6 @@ public class HanRiverMeetupApplication extends Application {
     public ISchedulerProvider getSchedulerProvider() {
         return SchedulerProvider.getInstance();
     }
-
 
     @NonNull
     public MeetingCategoryViewModel getMeetingCategoryViewModel() {

--- a/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/common/PreferencesManager.java
+++ b/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/common/PreferencesManager.java
@@ -1,0 +1,64 @@
+package com.depromeet.hanriver.hanrivermeetup.common;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import static android.content.Context.MODE_PRIVATE;
+
+public class PreferencesManager {
+    private static String BASE_STORE_PROPERTY_NAME = "pre";
+    private static String FCM_TOKEN_PROPERTY_NAME = "FCM_TOKEN";
+    private static String FACEBOOK_TOKEN_PROPERTY_NAME = "FACEBOOK_TOKEN";
+    private static String USER_ID_PROPERTY_NAME = "USER_ID";
+    private static String NICKNAME_PROPERTY_NAME = "NICKNAME";
+
+    private static SharedPreferences pref = null;
+
+    public static void setManager(Context context) {
+        if(pref == null) {
+            pref = context.getSharedPreferences(
+                    BASE_STORE_PROPERTY_NAME,
+                    MODE_PRIVATE);
+        }
+    }
+
+    public static String getFcmToken() {
+        return pref.getString(FCM_TOKEN_PROPERTY_NAME, "");
+    }
+
+    public static void setFcmToken(String token) {
+        SharedPreferences.Editor editor = pref.edit();
+        editor.putString(FCM_TOKEN_PROPERTY_NAME, token);
+        editor.commit();
+    }
+
+    public static String getFacebookToken() {
+        return pref.getString(FACEBOOK_TOKEN_PROPERTY_NAME, "");
+    }
+
+    public static void setFacebookToken(String token) {
+        SharedPreferences.Editor editor = pref.edit();
+        editor.putString(FACEBOOK_TOKEN_PROPERTY_NAME, token);
+        editor.commit();
+    }
+
+    public static String getNickname() {
+        return pref.getString(NICKNAME_PROPERTY_NAME, "");
+    }
+
+    public static void setNickname(String nickname) {
+        SharedPreferences.Editor editor = pref.edit();
+        editor.putString(NICKNAME_PROPERTY_NAME, nickname);
+        editor.commit();
+    }
+
+    public static String getUserID() {
+        return pref.getString(USER_ID_PROPERTY_NAME, "");
+    }
+
+    public static void setUserID(String userID) {
+        SharedPreferences.Editor editor = pref.edit();
+        editor.putString(USER_ID_PROPERTY_NAME, userID);
+        editor.commit();
+    }
+}

--- a/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/firebase/CustomFirebaseInstanceIDService.java
+++ b/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/firebase/CustomFirebaseInstanceIDService.java
@@ -1,6 +1,5 @@
 package com.depromeet.hanriver.hanrivermeetup.firebase;
 
-import android.content.SharedPreferences;
 import android.util.Log;
 
 import com.google.firebase.iid.FirebaseInstanceId;
@@ -11,59 +10,11 @@ public class CustomFirebaseInstanceIDService extends FirebaseInstanceIdService {
 
     @Override
     public void onTokenRefresh() {
-        // Get updated InstanceID token.
         String refreshedToken = FirebaseInstanceId.getInstance().getToken();
         Log.d(TAG, "Refreshed token: " + refreshedToken);
-
-//        if (refreshedToken!=null) {
-//            SettingPreferences.setStringValueInPref(this, SettingPreferences.REG_ID, refreshedToken);
-//        }
-        // TODO: Implement this method to send any registration to your app's servers.
-        sendRegistrationToServer(refreshedToken);
     }
 
-    private void sendRegistrationToServer(String token) {
-        // Add custom implementation, as needed.
+    public static String getToken() {
+        return FirebaseInstanceId.getInstance().getToken();
     }
 }
-
-//    private String AD_FCM_TOKEN = "AD_FCM_TOKEN";
-//
-//    @Override
-//    public void onTokenRefresh() {
-//        String refreshedToken = FirebaseInstanceId.getInstance().getToken();
-//
-//        if (isValidString(refreshedToken)) { //토큰이 널이거나 빈 문자열이 아닌 경우
-//            if (!isValidString(getSharedPreferencesStringData())) { //토큰에 데이터가 없는 경우에만 저장
-//                setSharedPreferencesStringData(refreshedToken);
-//            }
-//
-//            if (isValidString(getSharedPreferencesStringData())) { //로그인 상태일 경우에는 서버로 보낸다.
-//                if (!refreshedToken.equals(getSharedPreferencesStringData())) { //기존에 저장된 토큰과 비교하여 다를 경우에만 서버 업데이트
-//                    setSharedPreferencesStringData(refreshedToken);
-//                    sendRegistrationToServer(refreshedToken);
-//                }
-//            }
-//        }
-//    }
-//
-//    private void sendRegistrationToServer(String token) {
-//        //FCM 토큰 갱신
-//    }
-//
-//    private void setSharedPreferencesStringData(String token){
-//        SharedPreferences pref = getSharedPreferences("pref", MODE_PRIVATE);
-//        SharedPreferences.Editor editor = pref.edit();
-//        editor.putString(AD_FCM_TOKEN, token);
-//        editor.commit();
-//    }
-//
-//    private String getSharedPreferencesStringData(){
-//        SharedPreferences pref = getSharedPreferences("pref", MODE_PRIVATE);
-//        return pref.getString(AD_FCM_TOKEN, "");
-//    }
-//
-//    private boolean isValidString(String token) {
-//        return token.isEmpty();
-//    }
-// }

--- a/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/fragment/login/CreateAccountFragment.java
+++ b/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/fragment/login/CreateAccountFragment.java
@@ -2,6 +2,7 @@ package com.depromeet.hanriver.hanrivermeetup.fragment.login;
 
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
@@ -11,13 +12,26 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
+import android.widget.Toast;
 
 import com.depromeet.hanriver.hanrivermeetup.R;
 import com.depromeet.hanriver.hanrivermeetup.activity.main.MainActivity;
+import com.depromeet.hanriver.hanrivermeetup.common.PreferencesManager;
 import com.depromeet.hanriver.hanrivermeetup.service.LoginService;
 import com.facebook.login.Login;
 
+import javax.net.ssl.HttpsURLConnection;
+
+import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.disposables.Disposable;
+
+import static android.content.Context.MODE_PRIVATE;
+
 public class CreateAccountFragment extends Fragment {
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+    }
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
@@ -25,27 +39,34 @@ public class CreateAccountFragment extends Fragment {
         View view = inflater.inflate(R.layout.fragment_create_account, container, false);
 
         Button registerButton = view.findViewById(R.id.create_nickname_button);
-        AppCompatEditText editText = view.findViewById(R.id.edit_nickname);;
-
-        Log.d("###nickname",""+ LoginFragment.getUser_id());
+        AppCompatEditText editText = view.findViewById(R.id.edit_nickname);
 
         registerButton.setOnClickListener(v -> {
-            String str = editText.getText().toString();
-            LoginService.getInstance().registerUser(str)
-                    .subscribe(res -> {
-                        if(res) {
-                            Intent intent = new Intent(getActivity(), MainActivity.class);
-                            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-                            startActivity(intent);
-                        }
-                    });
+            String nickName = editText.getText().toString();
+
+            if(!nickName.isEmpty()) {
+                LoginService.getInstance().registerUser(nickName)
+                        .observeOn(AndroidSchedulers.mainThread())
+                        .doOnNext(res -> {
+                            if(res.code() == HttpsURLConnection.HTTP_OK) {
+                                intentMain();
+                            }
+                            else {
+                                Toast.makeText(getActivity(), "이미 가입된 아이디입니다.",
+                                        Toast.LENGTH_SHORT).show();
+                            }
+                        })
+                        .subscribe();
+            }
         });
 
         return view;
     }
 
-    @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+    private void intentMain() {
+        Intent intent = new Intent(getActivity(), MainActivity.class);
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        startActivity(intent);
+        this.getActivity().finish();
     }
 }

--- a/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/fragment/login/LoginFragment.java
+++ b/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/fragment/login/LoginFragment.java
@@ -1,16 +1,16 @@
 package com.depromeet.hanriver.hanrivermeetup.fragment.login;
 
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
-import android.text.TextUtils;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
 import com.depromeet.hanriver.hanrivermeetup.R;
 import com.depromeet.hanriver.hanrivermeetup.activity.main.MainActivity;
+import com.depromeet.hanriver.hanrivermeetup.common.PreferencesManager;
 import com.depromeet.hanriver.hanrivermeetup.service.LoginService;
 import com.facebook.AccessToken;
 import com.facebook.CallbackManager;
@@ -19,13 +19,17 @@ import com.facebook.FacebookException;
 import com.facebook.login.LoginResult;
 import com.facebook.login.widget.LoginButton;
 
-public class LoginFragment extends Fragment{
+import javax.net.ssl.HttpsURLConnection;
+
+import io.reactivex.android.schedulers.AndroidSchedulers;
+
+import static android.content.Context.MODE_PRIVATE;
+
+public class LoginFragment extends Fragment {
     // LoginManager loginManager; // 로그인 상태인지 아닌지 확인 할 것 (버튼을 커스텀으로 생성할 시 필요)
     LoginButton fb_loginButton; // 커스텀 아닌 기본 제공되는 버튼.
     CallbackManager callbackManager; //요청 응답 받을 것
 
-    private static String accessed_token; // 로그인 되어있을 경우 저장된 토큰
-    private static String user_id;
     private static String nick_name;
 
     @Override
@@ -34,9 +38,9 @@ public class LoginFragment extends Fragment{
 
         View view = inflater.inflate(R.layout.fragment_login, container, false);
 
-        if(AccessToken.getCurrentAccessToken() != null) { //기존 로그인 되어있을 경우
-            accessed_token = AccessToken.getCurrentAccessToken().getToken();
-            user_id = AccessToken.getCurrentAccessToken().getUserId();
+        if (AccessToken.getCurrentAccessToken() != null) { //기존 로그인 되어있을 경우
+            String accessed_token = AccessToken.getCurrentAccessToken().getToken();
+            String user_id = AccessToken.getCurrentAccessToken().getUserId();
             login(user_id, accessed_token);
         }
 
@@ -48,9 +52,6 @@ public class LoginFragment extends Fragment{
             public void onSuccess(LoginResult loginResult) { //로그인 버튼 눌러서 로그인 성공 시
                 String id = loginResult.getAccessToken().getUserId();
                 String token = loginResult.getAccessToken().getToken();
-
-                setAccessed_token(loginResult.getAccessToken().getToken());
-
                 login(id, token);
             }
 
@@ -69,24 +70,28 @@ public class LoginFragment extends Fragment{
     }
 
     private void login(String id, String token) {
+        PreferencesManager.setUserID(id);
+        PreferencesManager.setFacebookToken(token);
+
         LoginService.getInstance().login(id, token)
-                .subscribe(user -> {
-                    if(user != null && TextUtils.isEmpty(user.nickname)) {
-                        getFragmentManager().beginTransaction().
-                                replace(R.id.login_activity_container, new CreateAccountFragment()).
-                                commitAllowingStateLoss();
+                .observeOn(AndroidSchedulers.mainThread())
+                .doOnNext(res -> {
+                    if(res.code() == HttpsURLConnection.HTTP_NOT_FOUND) {
+                        replaceRegisterPage();
                     }
-                    else if(!TextUtils.isEmpty(user.nickname)) {
-                        setNick_name(user.nickname);
-                        moveToMain();
+                    else {
+                        PreferencesManager.setNickname(res.body().nickname);
+                        intentMain();
                     }
-                });
+                })
+                .subscribe();
     }
 
-    private void moveToMain() {
-        // TODO : 추후 로그인 백스택을 모두 지워야함
-        Intent i = new Intent(getActivity(), MainActivity.class);
-        startActivity(i);
+    private void intentMain() {
+        Intent intent = new Intent(getActivity(), MainActivity.class);
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        startActivity(intent);
+        this.getActivity().finish();
     }
 
     @Override
@@ -100,23 +105,9 @@ public class LoginFragment extends Fragment{
         callbackManager.onActivityResult(requestCode, resultCode, data);
     }
 
-    public static String getAccessed_token() {
-        return accessed_token;
-    }
-
-    public static void setAccessed_token(String accessed_token) {
-        LoginFragment.accessed_token = accessed_token;
-    }
-
-    public static String getUser_id() {
-        return user_id;
-    }
-
-    public static String getNick_name() {
-        return nick_name;
-    }
-
-    public static void setNick_name(String nick_name) {
-        LoginFragment.nick_name = nick_name;
+    private void replaceRegisterPage() {
+        getFragmentManager().beginTransaction().
+                replace(R.id.login_activity_container, new CreateAccountFragment()).
+                commitAllowingStateLoss();
     }
 }

--- a/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/fragment/meeting/MeetingCategoryFragment.java
+++ b/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/fragment/meeting/MeetingCategoryFragment.java
@@ -17,6 +17,7 @@ import android.widget.TextView;
 import com.depromeet.hanriver.hanrivermeetup.activity.main.MainActivity;
 import com.depromeet.hanriver.hanrivermeetup.HanRiverMeetupApplication;
 import com.depromeet.hanriver.hanrivermeetup.R;
+import com.depromeet.hanriver.hanrivermeetup.common.PreferencesManager;
 import com.depromeet.hanriver.hanrivermeetup.fragment.login.LoginFragment;
 import com.depromeet.hanriver.hanrivermeetup.fragment.meeting.Adapter.Category.MeetingCategoryAdapter;
 import com.depromeet.hanriver.hanrivermeetup.model.meeting.Activity;
@@ -72,7 +73,7 @@ public class MeetingCategoryFragment extends Fragment {
         weather_temp = v.findViewById(R.id.weather_temp);
         weather_temp_sub = v.findViewById(R.id.weather_temp_sub);
         mActivitesView = v.findViewById(R.id.category_main_text);
-        mActivitesView.setText(LoginFragment.getNick_name()+" 님\n한강에서 즐겨볼까요?");
+        mActivitesView.setText(PreferencesManager.getNickname()+" 님\n한강에서 즐겨볼까요?");
 //        gridview = v.findViewById(R.id.gridview);
         recyclerView = v.findViewById(R.id.category_rv);
         recyclerView.setOverScrollMode(View.OVER_SCROLL_NEVER);

--- a/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/fragment/meeting/MeetingCreateRoom.java
+++ b/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/fragment/meeting/MeetingCreateRoom.java
@@ -31,6 +31,7 @@ import android.widget.Toast;
 
 import com.depromeet.hanriver.hanrivermeetup.R;
 import com.depromeet.hanriver.hanrivermeetup.activity.main.MainActivity;
+import com.depromeet.hanriver.hanrivermeetup.common.PreferencesManager;
 import com.depromeet.hanriver.hanrivermeetup.fragment.login.LoginFragment;
 import com.depromeet.hanriver.hanrivermeetup.fragment.meeting.Adapter.CreateRoom.ExpandableListAdapter;
 import com.depromeet.hanriver.hanrivermeetup.fragment.meeting.Utils.CreateRoomLocationFragment;
@@ -152,14 +153,14 @@ public class MeetingCreateRoom extends DialogFragment {
         contact = v.findViewById(R.id.create_room_contact);
         fee = v.findViewById(R.id.create_room_fee);
         num = v.findViewById(R.id.create_room_num);
-        nickname.setText(LoginFragment.getNick_name());
+        nickname.setText(PreferencesManager.getNickname());
 
         num.addTextChangedListener(textWatcher);
         fee.addTextChangedListener(textWatcher);
         contact.addTextChangedListener(textWatcher);
         roomname.addTextChangedListener(textWatcher);
 
-        Picasso.get().load(FacebookService.getInstance().getProfileURL(LoginFragment.getUser_id()))
+        Picasso.get().load(FacebookService.getInstance().getProfileURL(PreferencesManager.getUserID()))
                 .transform(CircleTransform.getInstance()).into(profileimg);
 
         time.setOnClickListener(new View.OnClickListener() {
@@ -210,7 +211,7 @@ public class MeetingCreateRoom extends DialogFragment {
                     md.setMeeting_time(getCurrentDate(time.getText().toString()));
                     md.setTitle(roomname.getText().toString());
                     md.setParticipants_cnt(Integer.parseInt(num.getText().toString()));
-                    md.setUser_id(LoginFragment.getUser_id().toString());
+                    md.setUser_id(PreferencesManager.getUserID());
                     md.setContact(contact.getText().toString());
 
                     mCompositeDisposable.add(HostService.getInstance().createMeeting(md)
@@ -266,7 +267,7 @@ public class MeetingCreateRoom extends DialogFragment {
 
     private void isCreated(@NonNull final List<MeetingDetail> Rooms) {
         for (int i = 0; i < Rooms.size(); i++) {
-            if (Rooms.get(i).getUser_id().equals(LoginFragment.getUser_id())) {
+            if (Rooms.get(i).getUser_id().equals(PreferencesManager.getUserID())) {
                 createbtn.setText("이미 방을 생성하였습니다.");
                 createbtn.setBackgroundColor(Color.parseColor("#aaaaaa"));
                 createbtn.setEnabled(false);

--- a/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/fragment/meeting/MeetingDetailFragment.java
+++ b/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/fragment/meeting/MeetingDetailFragment.java
@@ -35,6 +35,7 @@ import com.baoyz.swipemenulistview.SwipeMenuItem;
 import com.baoyz.swipemenulistview.SwipeMenuListView;
 import com.depromeet.hanriver.hanrivermeetup.HanRiverMeetupApplication;
 import com.depromeet.hanriver.hanrivermeetup.R;
+import com.depromeet.hanriver.hanrivermeetup.common.PreferencesManager;
 import com.depromeet.hanriver.hanrivermeetup.fragment.login.LoginFragment;
 import com.depromeet.hanriver.hanrivermeetup.fragment.meeting.Adapter.Detail.MeetingCommentAdapter;
 import com.depromeet.hanriver.hanrivermeetup.helper.CircleTransform;
@@ -146,7 +147,7 @@ public class MeetingDetailFragment extends DialogFragment {
                 comment.setText(comment_text.getText().toString());
                 comment.setMeeting_seq(meeting_seq);
                 comment.setCreatedTime(getCurrentTime());
-                comment.setUserID(LoginFragment.getUser_id());
+                comment.setUserID(PreferencesManager.getUserID());
 
                 mCompositeDisposable.add(CommunicationService.getInstance().addComment(comment)
                         .subscribeOn(Schedulers.computation())
@@ -258,7 +259,7 @@ public class MeetingDetailFragment extends DialogFragment {
 
     private void getApplicationSeq(@NonNull final List<ApplicantVO> applicantVOs) {
         for (int i = 0; i < applicantVOs.size(); i++) {
-            if (applicantVOs.get(i).getUserId().equals(LoginFragment.getUser_id())) {
+            if (applicantVOs.get(i).getUserId().equals(PreferencesManager.getUserID())) {
                 join_btn.setBackgroundColor(Color.parseColor("#aaaaaa"));
                 join_btn.setEnabled(false);
                 join_btn.setText("이미 참여한 모임입니다");
@@ -284,7 +285,7 @@ public class MeetingDetailFragment extends DialogFragment {
         Picasso.get().load(FacebookService.getInstance().getProfileURL(meetingDetail.getUser_id()))
                 .transform(CircleTransform.getInstance()).into(profile_img);
 
-        if (meetingDetail.getUser_id().equals(LoginFragment.getUser_id())) {
+        if (meetingDetail.getUser_id().equals(PreferencesManager.getUserID())) {
 //            join_btn.setBackgroundColor(Color.parseColor("#aaaaaa"));
 //            join_btn.setEnabled(false);
 //            join_btn.setText("내가 만든 방입니다");
@@ -308,7 +309,7 @@ public class MeetingDetailFragment extends DialogFragment {
     private void setComments(@NonNull final List<Comment> comments) {
 
         rv.setOnMenuItemClickListener((position, menu, index) -> {
-            if (LoginFragment.getUser_id().equals(comments.get(position).getUserID())) {
+            if (PreferencesManager.getUserID().equals(comments.get(position).getUserID())) {
                 switch (index) {
                     case 0:
                         mCompositeDisposable.add(CommunicationService.getInstance().deleteComment(comments.get(position).getId())
@@ -392,7 +393,6 @@ public class MeetingDetailFragment extends DialogFragment {
     public static void setListViewHeightBasedOnChildren(SwipeMenuListView listView) {
         ListAdapter listAdapter = listView.getAdapter();
         if (listAdapter == null) {
-            // pre-condition
             return;
         }
 

--- a/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/fragment/meeting/MeetingJoinFragment.java
+++ b/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/fragment/meeting/MeetingJoinFragment.java
@@ -17,6 +17,7 @@ import android.widget.TextView;
 
 import com.depromeet.hanriver.hanrivermeetup.HanRiverMeetupApplication;
 import com.depromeet.hanriver.hanrivermeetup.R;
+import com.depromeet.hanriver.hanrivermeetup.common.PreferencesManager;
 import com.depromeet.hanriver.hanrivermeetup.fragment.login.LoginFragment;
 import com.depromeet.hanriver.hanrivermeetup.helper.CircleTransform;
 import com.depromeet.hanriver.hanrivermeetup.model.meeting.JoinRequest;
@@ -94,9 +95,10 @@ public class MeetingJoinFragment extends DialogFragment {
         reason = v.findViewById(R.id.join_reason);
         textCounter = v.findViewById(R.id.join_content_counter);
         join_btn = v.findViewById(R.id.join_btn);
-        nickname.setText(LoginFragment.getNick_name());
+        nickname.setText(PreferencesManager.getNickname());
 
-        Picasso.get().load(FacebookService.getInstance().getProfileURL(LoginFragment.getUser_id()))
+        Picasso.get().load(FacebookService.getInstance()
+                .getProfileURL(PreferencesManager.getUserID()))
                 .transform(CircleTransform.getInstance()).into(profile_img);
 
         join_btn.setOnClickListener(new View.OnClickListener() {
@@ -108,7 +110,7 @@ public class MeetingJoinFragment extends DialogFragment {
                 joinRequest.setDescription(reason.getText().toString());
                 joinRequest.setMeetingID(meeting_seq);
                 joinRequest.setParticipantsCnt(Integer.parseInt(numofMem.getText().toString()));
-                joinRequest.setUserID(LoginFragment.getUser_id());
+                joinRequest.setUserID(PreferencesManager.getUserID());
 
 
 

--- a/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/fragment/meeting/MeetingModifyRoom.java
+++ b/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/fragment/meeting/MeetingModifyRoom.java
@@ -18,6 +18,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import com.depromeet.hanriver.hanrivermeetup.R;
+import com.depromeet.hanriver.hanrivermeetup.common.PreferencesManager;
 import com.depromeet.hanriver.hanrivermeetup.fragment.login.LoginFragment;
 import com.depromeet.hanriver.hanrivermeetup.fragment.meeting.Utils.CreateRoomLocationFragment;
 import com.depromeet.hanriver.hanrivermeetup.fragment.meeting.Utils.TimePickerFragment;
@@ -106,7 +107,7 @@ public class MeetingModifyRoom extends DialogFragment {
         contact = v.findViewById(R.id.modify_room_contact);
         fee = v.findViewById(R.id.modify_room_fee);
         num = v.findViewById(R.id.modify_room_num);
-        nickname.setText(LoginFragment.getNick_name());
+        nickname.setText(PreferencesManager.getNickname());
 
         //본래 정보 등록.
         roomname.setText(meetingDetail.getTitle());
@@ -119,8 +120,10 @@ public class MeetingModifyRoom extends DialogFragment {
         fee.setText(String.valueOf(meetingDetail.getExpected_cost()));
         num.setText(String.valueOf(meetingDetail.getParticipants_cnt()));
 
-        Picasso.get().load(FacebookService.getInstance().getProfileURL(LoginFragment.getUser_id()))
-                .transform(CircleTransform.getInstance()).into(profileimg);
+        Picasso.get().load(FacebookService.getInstance()
+                .getProfileURL(PreferencesManager.getUserID()))
+                .transform(CircleTransform.getInstance())
+                .into(profileimg);
 
         time.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -150,7 +153,7 @@ public class MeetingModifyRoom extends DialogFragment {
                 md.setMeeting_time(getCurrentDate(time.getText().toString()));
                 md.setTitle(roomname.getText().toString());
                 md.setParticipants_cnt(Integer.parseInt(num.getText().toString()));
-                md.setUser_id(LoginFragment.getUser_id().toString());
+                md.setUser_id(PreferencesManager.getUserID());
                 md.setContact(contact.getText().toString());
 
                 mCompositeDisposable.add(HostService.getInstance().modifyMeeting(meetingDetail.getMeeting_seq(),md)

--- a/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/fragment/meeting/map/TmapFragment.java
+++ b/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/fragment/meeting/map/TmapFragment.java
@@ -31,7 +31,7 @@ public class TmapFragment extends Fragment {
 
         map = view.findViewById(R.id.mapView);
         mapView = new TMapView(getActivity());
-        mapView.setSKTMapApiKey(BuildConfig.TMapApiKey);
+        // mapView.setSKTMapApiKey(BuildConfig.TMapApiKey);
 
         mapView.setLocationPoint(126.970325,37.556152);
         mapView.setCenterPoint(126.970325,37.556152);

--- a/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/fragment/mypage/Adapter/Tab3Adapter.java
+++ b/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/fragment/mypage/Adapter/Tab3Adapter.java
@@ -17,6 +17,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import com.depromeet.hanriver.hanrivermeetup.R;
+import com.depromeet.hanriver.hanrivermeetup.common.PreferencesManager;
 import com.depromeet.hanriver.hanrivermeetup.fragment.login.LoginFragment;
 import com.depromeet.hanriver.hanrivermeetup.fragment.mypage.SelectionDialog;
 import com.depromeet.hanriver.hanrivermeetup.fragment.mypage.Tab3;
@@ -59,7 +60,8 @@ public class Tab3Adapter extends RecyclerView.Adapter<Tab3Adapter.ItemViewHolder
         holder.mParticipants.setText(String.valueOf(mItems.get(position).getMeetingDetail().getParticipantsCnt()));
 
         //참가자인지 주최자인지 구별하는 Logic
-        if(TextUtils.equals(LoginFragment.getUser_id(), mItems.get(position).getJoinDetail().getUserId()))
+        if(TextUtils.equals(PreferencesManager.getUserID(),
+                mItems.get(position).getJoinDetail().getUserId()))
         {
             holder.mInfoButton.setImageResource(R.drawable.ic_contact_blue_icon);
             holder.mInfoButton.setOnClickListener(new View.OnClickListener() {

--- a/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/fragment/mypage/MatchingDialog.java
+++ b/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/fragment/mypage/MatchingDialog.java
@@ -18,6 +18,7 @@ import android.widget.Toast;
 
 import com.airbnb.lottie.LottieAnimationView;
 import com.depromeet.hanriver.hanrivermeetup.R;
+import com.depromeet.hanriver.hanrivermeetup.common.PreferencesManager;
 import com.depromeet.hanriver.hanrivermeetup.fragment.login.LoginFragment;
 import com.depromeet.hanriver.hanrivermeetup.helper.CircleTransform;
 import com.depromeet.hanriver.hanrivermeetup.model.meeting.MatchingDetail;
@@ -46,7 +47,7 @@ public class MatchingDialog extends Dialog {
 
         Initialize();
 
-        SetData(LoginFragment.getNick_name(),
+        SetData(PreferencesManager.getNickname(),
                 applicantVO.getNickname(),
                 applicantVO.getUserId(),
                 applicantVO.getParticipantsCnt(),

--- a/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/fragment/mypage/MyPageFragment.java
+++ b/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/fragment/mypage/MyPageFragment.java
@@ -20,6 +20,7 @@ import android.widget.TextView;
 
 import com.depromeet.hanriver.hanrivermeetup.HanRiverMeetupApplication;
 import com.depromeet.hanriver.hanrivermeetup.R;
+import com.depromeet.hanriver.hanrivermeetup.common.PreferencesManager;
 import com.depromeet.hanriver.hanrivermeetup.fragment.login.LoginFragment;
 import com.depromeet.hanriver.hanrivermeetup.fragment.mypage.Adapter.Tab3Adapter;
 import com.depromeet.hanriver.hanrivermeetup.fragment.mypage.ViewModel.Tab3ViewModel;
@@ -80,7 +81,7 @@ public class MyPageFragment extends Fragment{
 
 
         main_text = view.findViewById(R.id.mypage_main_text);
-        main_text.setText("안녕하세요\n"+LoginFragment.getNick_name()+" 님 반가워요");
+        main_text.setText("안녕하세요\n" + PreferencesManager.getNickname() + " 님 반가워요");
 
         // Initializing the TabLayout
         tabLayout = view.findViewById(R.id.tablayout2);
@@ -114,11 +115,12 @@ public class MyPageFragment extends Fragment{
 
         //Profile Setting
         profile_img = (ImageView)view.findViewById(R.id.profile_img);
-        Picasso.get().load(FacebookService.getInstance().getProfileURL(LoginFragment.getUser_id()))
+        Picasso.get().load(FacebookService.getInstance()
+                .getProfileURL(PreferencesManager.getUserID()))
                 .transform(CircleTransform.getInstance()).into(profile_img);
 
         user_name = (TextView)view.findViewById(R.id.user_name);
-        user_name.setText(LoginFragment.getNick_name());
+        user_name.setText(PreferencesManager.getNickname());
 
         // Set TabSelectedListener
         tabLayout.addOnTabSelectedListener(new TabLayout.OnTabSelectedListener() {
@@ -186,17 +188,20 @@ public class MyPageFragment extends Fragment{
     private void bind() {
         mCompositeDisposable = new CompositeDisposable();
 
-        mCompositeDisposable.add(MyPageService.getInstance().getMyMeeting(LoginFragment.getUser_id())
+        mCompositeDisposable.add(MyPageService.getInstance()
+                .getMyMeeting(PreferencesManager.getUserID())
                 .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(this::setTab1Count));
 
-        mCompositeDisposable.add(MyPageService.getInstance().getAppliedMeeting(LoginFragment.getUser_id())
+        mCompositeDisposable.add(MyPageService.getInstance()
+                .getAppliedMeeting(PreferencesManager.getUserID())
                 .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(this::setTab2Count));
 
-        mCompositeDisposable.add(MyPageService.getInstance().getMathcedMeeting(LoginFragment.getUser_id())
+        mCompositeDisposable.add(MyPageService.getInstance()
+                .getMathcedMeeting(PreferencesManager.getUserID())
                 .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(this::setTab3Count));

--- a/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/fragment/mypage/Tab1.java
+++ b/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/fragment/mypage/Tab1.java
@@ -14,6 +14,7 @@ import android.widget.LinearLayout;
 
 import com.depromeet.hanriver.hanrivermeetup.HanRiverMeetupApplication;
 import com.depromeet.hanriver.hanrivermeetup.R;
+import com.depromeet.hanriver.hanrivermeetup.common.PreferencesManager;
 import com.depromeet.hanriver.hanrivermeetup.fragment.login.LoginFragment;
 import com.depromeet.hanriver.hanrivermeetup.fragment.mypage.Adapter.Tab1Adapter;
 import com.depromeet.hanriver.hanrivermeetup.fragment.mypage.ViewModel.Tab1ViewModel;
@@ -47,7 +48,7 @@ public class Tab1 extends Fragment{
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        Log.d("@@test loginID", "" + LoginFragment.getUser_id());
+        Log.d("@@test loginID", "" + PreferencesManager.getUserID());
 
     }
 
@@ -86,7 +87,8 @@ public class Tab1 extends Fragment{
     private void bind() {
         mCompositeDisposable = new CompositeDisposable();
 
-        mCompositeDisposable.add(MyPageService.getInstance().getMyMeeting(LoginFragment.getUser_id())
+        mCompositeDisposable.add(MyPageService.getInstance()
+                .getMyMeeting(PreferencesManager.getUserID())
                 .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(this::setTab1VOs));

--- a/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/fragment/mypage/Tab2.java
+++ b/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/fragment/mypage/Tab2.java
@@ -19,6 +19,7 @@ import com.baoyz.swipemenulistview.SwipeMenuItem;
 import com.baoyz.swipemenulistview.SwipeMenuListView;
 import com.depromeet.hanriver.hanrivermeetup.HanRiverMeetupApplication;
 import com.depromeet.hanriver.hanrivermeetup.R;
+import com.depromeet.hanriver.hanrivermeetup.common.PreferencesManager;
 import com.depromeet.hanriver.hanrivermeetup.fragment.login.LoginFragment;
 import com.depromeet.hanriver.hanrivermeetup.fragment.mypage.Adapter.Tab2Adapter;
 import com.depromeet.hanriver.hanrivermeetup.fragment.mypage.Adapter.Tab3Adapter;
@@ -140,7 +141,8 @@ public class Tab2 extends Fragment {
     private void bind() {
         mCompositeDisposable = new CompositeDisposable();
 
-        mCompositeDisposable.add(MyPageService.getInstance().getAppliedMeeting(LoginFragment.getUser_id())
+        mCompositeDisposable.add(MyPageService.getInstance()
+                .getAppliedMeeting(PreferencesManager.getUserID())
                 .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(this::setTab2VOs));

--- a/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/fragment/mypage/Tab3.java
+++ b/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/fragment/mypage/Tab3.java
@@ -15,6 +15,7 @@ import android.widget.LinearLayout;
 
 import com.depromeet.hanriver.hanrivermeetup.HanRiverMeetupApplication;
 import com.depromeet.hanriver.hanrivermeetup.R;
+import com.depromeet.hanriver.hanrivermeetup.common.PreferencesManager;
 import com.depromeet.hanriver.hanrivermeetup.fragment.login.LoginFragment;
 import com.depromeet.hanriver.hanrivermeetup.fragment.mypage.Adapter.Tab3Adapter;
 import com.depromeet.hanriver.hanrivermeetup.fragment.mypage.ViewModel.Tab3ViewModel;
@@ -102,7 +103,8 @@ public class Tab3 extends Fragment {
 //                .observeOn(AndroidSchedulers.mainThread())
 //                .subscribe(this::setTab3VOs));
 
-        mCompositeDisposable.add(MyPageService.getInstance().getMathcedMeeting(LoginFragment.getUser_id())
+        mCompositeDisposable.add(MyPageService.getInstance()
+                .getMathcedMeeting(PreferencesManager.getUserID())
                 .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(this::setTab3VOs));

--- a/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/model/user/LoginInfo.java
+++ b/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/model/user/LoginInfo.java
@@ -8,4 +8,7 @@ public class LoginInfo {
 
     @SerializedName("user_id")
     public String userID;
+
+    @SerializedName("fcm_token")
+    public String fcmToken;
 }

--- a/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/model/user/User.java
+++ b/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/model/user/User.java
@@ -22,4 +22,7 @@ public class User {
 
     @SerializedName("creation_time")
     public Date creationTime;
+
+    @SerializedName("fcm_token")
+    public String fcmToken;
 }

--- a/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/network/APIUtiles.java
+++ b/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/network/APIUtiles.java
@@ -15,8 +15,6 @@ public class APIUtiles {
     public static final String WEATHER_API_URL = BASE_URL + "weather/";
     public static final String FACEBOOK_API_URL = "https://graph.facebook.com/";
 
-
-
     public static LoginAPIService getLoginService(){
         return RetrofitClient.getClient(ACCESS_API_URL).create(LoginAPIService.class);
     }

--- a/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/network/LoginAPIService.java
+++ b/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/network/LoginAPIService.java
@@ -6,13 +6,14 @@ import com.depromeet.hanriver.hanrivermeetup.model.user.User;
 import java.util.HashMap;
 
 import io.reactivex.Observable;
+import retrofit2.Response;
 import retrofit2.http.Body;
 import retrofit2.http.POST;
 
 public interface LoginAPIService {
-    @POST("loginValidate/")
-    Observable<User> getAccessToken(@Body LoginInfo loginInfo);
+    @POST("login/")
+    Observable<Response<User>> getAccessToken(@Body LoginInfo loginInfo);
 
-    @POST("registUser/")
-    Observable<User> registerUser(@Body HashMap<String, Object> userJoinInfoObject);
+    @POST("register/")
+    Observable<Response<User>> registerUser(@Body HashMap<String, Object> userJoinInfoObject);
 }

--- a/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/service/CommunicationService.java
+++ b/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/service/CommunicationService.java
@@ -27,25 +27,21 @@ public class CommunicationService {
 
     public Observable<List<Comment>> getComments(int meetingId){
         return mService.getComments(meetingId)
-                .subscribeOn(Schedulers.io())
-                .map(it -> it);
+                .subscribeOn(Schedulers.io());
     }
 
     public Observable<Comment> addComment(Comment comment){
         return mService.addComment(comment)
-                .subscribeOn(Schedulers.io())
-                .map(it -> it);
+                .subscribeOn(Schedulers.io());
     }
 
     public Observable<MatchingDetail> match(MatchingDetail matchingDetail){
         return mService.match(matchingDetail)
-                .subscribeOn(Schedulers.io())
-                .map(it->it);
+                .subscribeOn(Schedulers.io());
     }
 
     public Observable<Boolean> deleteComment(int comment_seq){
         return mService.deleteComment(comment_seq)
-                .subscribeOn(Schedulers.io())
-                .map(it->it);
+                .subscribeOn(Schedulers.io());
     }
 }

--- a/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/service/FacebookService.java
+++ b/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/service/FacebookService.java
@@ -41,10 +41,7 @@ public class FacebookService {
         }
 
         return mService.getProfileById(userID)
-                .subscribeOn(Schedulers.io())
-                .map(it -> {
-                    return it;
-                });
+                .subscribeOn(Schedulers.io());
     }
 
     public String getProfileURL(String userID) {

--- a/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/service/HostService.java
+++ b/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/service/HostService.java
@@ -35,24 +35,22 @@ public class HostService {
 
     public Observable<List<ApplicantVO>> getMeetingApplicants(int meeting_seq){
         return mService.getMeetingApplicants(meeting_seq)
-                .subscribeOn(Schedulers.io())
-                .map(it -> it);
+                .subscribeOn(Schedulers.io());
     }
     public Observable<List<MeetingDetail>> getTodayList(){
         return mService.getMeetingsOnToday()
-                .subscribeOn(Schedulers.io())
-                .map(it -> it);
+                .subscribeOn(Schedulers.io());
     }
 
     public Observable<MeetingDetail> getMeetingDetail(int meeting_seq){
-        return mService.getMeetingDetail(meeting_seq).subscribeOn(Schedulers.io()).map(it->it);
+        return mService.getMeetingDetail(meeting_seq).subscribeOn(Schedulers.io());
     }
 
     public Observable<MeetingDetail> createMeeting(MeetingDetail createRoom){
-        return mService.createMeeting(createRoom).subscribeOn(Schedulers.io()).map(it->it);
+        return mService.createMeeting(createRoom).subscribeOn(Schedulers.io());
     }
 
     public Observable<MeetingDetail> modifyMeeting(int meeting_seq ,MeetingDetail meetingDetail){
-        return mService.modifyMeeting(meeting_seq, meetingDetail).subscribeOn(Schedulers.io()).map(it->it);
+        return mService.modifyMeeting(meeting_seq, meetingDetail).subscribeOn(Schedulers.io());
     }
 }

--- a/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/service/LoginService.java
+++ b/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/service/LoginService.java
@@ -1,29 +1,26 @@
 package com.depromeet.hanriver.hanrivermeetup.service;
 
 import android.text.TextUtils;
-import android.util.Log;
 
+import com.depromeet.hanriver.hanrivermeetup.common.PreferencesManager;
+import com.depromeet.hanriver.hanrivermeetup.firebase.CustomFirebaseInstanceIDService;
 import com.depromeet.hanriver.hanrivermeetup.model.user.LoginInfo;
 import com.depromeet.hanriver.hanrivermeetup.model.user.User;
 import com.depromeet.hanriver.hanrivermeetup.network.APIUtiles;
 import com.depromeet.hanriver.hanrivermeetup.network.LoginAPIService;
 
-import java.io.IOException;
 import java.security.InvalidParameterException;
 import java.util.HashMap;
 
+import javax.net.ssl.HttpsURLConnection;
+
 import io.reactivex.Observable;
-import io.reactivex.Scheduler;
-import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.schedulers.Schedulers;
-import retrofit2.Call;
-import retrofit2.Callback;
 import retrofit2.Response;
 
 public class LoginService {
     private static final LoginService ourInstance = new LoginService();
     private LoginAPIService mService;
-    private String userID = null;
 
     public static LoginService getInstance() {
         return ourInstance;
@@ -33,37 +30,52 @@ public class LoginService {
         mService = APIUtiles.getLoginService();
     }
 
-    public Observable<User> login(String id, String facebookAccessToken) {
-
+    public Observable<Response<User>> login(String id, String facebookAccessToken) {
         LoginInfo loginInfo = new LoginInfo();
         loginInfo.userID = id;
         loginInfo.accessToken = facebookAccessToken;
+        loginInfo.fcmToken = PreferencesManager.getFcmToken();
 
-        return mService.getAccessToken(loginInfo)
+        return mService.getAccessToken(createUser(id, facebookAccessToken))
                 .subscribeOn(Schedulers.io())
-                .map(it -> {
-                    setServices(it.hangangToken, it.userID);
-                    return it;
+                .doOnNext(res -> {
+                    if(res.code() == HttpsURLConnection.HTTP_OK) {
+                        setServices(res.body().hangangToken, res.body().userID);
+                    }
                 });
     }
 
-    public Observable<Boolean> registerUser(String nickname) {
-        if(TextUtils.isEmpty(nickname) || TextUtils.isEmpty(userID)) {
+    private LoginInfo createUser(String id, String facebookAccessToken) {
+        LoginInfo loginInfo = new LoginInfo();
+        loginInfo.userID = id;
+        loginInfo.accessToken = facebookAccessToken;
+        loginInfo.fcmToken = CustomFirebaseInstanceIDService.getToken();
+
+        return loginInfo;
+    }
+
+    public Observable<Response<User>> registerUser(String nickname) {
+        if(TextUtils.isEmpty(nickname)) {
             return Observable.create(subscriber ->
                     subscriber.onError(new InvalidParameterException("registerUser : Wrong parameter")));
         }
 
         HashMap<String, Object> userJoinInfoObject = new HashMap<>();
         userJoinInfoObject.put("nickname", nickname);
-        userJoinInfoObject.put("user_id", userID);
+        userJoinInfoObject.put("user_id", PreferencesManager.getUserID());
+        userJoinInfoObject.put("access_token", PreferencesManager.getFacebookToken());
+        userJoinInfoObject.put("fcm_token", PreferencesManager.getFcmToken());
 
         return mService.registerUser(userJoinInfoObject)
                 .subscribeOn(Schedulers.io())
-                .map(it -> it != null);
+                .doOnNext(res -> {
+                    if(res.code() == HttpsURLConnection.HTTP_OK) {
+                        setServices(res.body().hangangToken, res.body().userID);
+                    }
+                });
     }
 
     private void setServices(String token, String id) {
-        userID = id;
         HostService.getInstance().setService(token, id);
         GuestService.getInstance().setService(token, id);
         CommunicationService.getInstance().setService(token, id);

--- a/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/service/MyPageService.java
+++ b/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/service/MyPageService.java
@@ -32,19 +32,16 @@ public class MyPageService {
 
     public Observable<List<Tab1VO>> getMyMeeting(String userID){
         return mService.getMyMeeting(userID)
-                .subscribeOn(Schedulers.io())
-                .map(it -> it);
+                .subscribeOn(Schedulers.io());
     }
 
     public Observable<List<Tab3VO>> getMathcedMeeting(String userID){
         return mService.getMatchedMeeting(userID)
-                .subscribeOn(Schedulers.io())
-                .map(it -> it);
+                .subscribeOn(Schedulers.io());
     }
 
     public Observable<List<Tab2VO>> getAppliedMeeting(String userID){
         return mService.getAppliedMeeting(userID)
-                .subscribeOn(Schedulers.io())
-                .map(it -> it);
+                .subscribeOn(Schedulers.io());
     }
 }

--- a/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/service/WeatherService.java
+++ b/app/src/main/java/com/depromeet/hanriver/hanrivermeetup/service/WeatherService.java
@@ -23,8 +23,7 @@ public class WeatherService {
 
     public Observable<Weather> getWeather(){
         return mService.getWeather()
-                .subscribeOn(Schedulers.io())
-                .map(it->it);
+                .subscribeOn(Schedulers.io());
     }
 
 }


### PR DESCRIPTION
* 현재 로그인 요청시 서버로부터 바로 등록되고, 닉네임이 없을 경우 가입을 시도하는 기형적인 구조.

* 로그인 시 아이디가 없으면 null 값을 리턴하고, 가입 페이지로 이동시키며, 닉네임을 설저하면 가입 요청하도록 로직 변경

* http error status code에 대한 대응 로직 추가

* 로그인 정보등을 sharedPreferences 로 관리

* 코드 리펙토링 수행
  - 불필요한 코드 제거